### PR TITLE
[Release] Bump 'swift-tools-version' from 5.3 to 5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 // Copyright 2023 Google LLC
 //


### PR DESCRIPTION
### Context
- Align with Firebase's minimum `swift-tools-version` (https://github.com/firebase/firebase-ios-sdk/pull/11046)