### PR TITLE
[grpc] Update grpc to fix firebase-ios-sdk/#12441

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,11 +21,11 @@ let package = Package(
   products: [
     .library(
       name: "gRPC-Core",
-      targets: ["grpc-Wrapper"]
+      targets: ["grpcWrapper"]
     ),
     .library(
       name: "gRPC-C++",
-      targets: ["grpcpp-Wrapper"]
+      targets: ["grpcppWrapper"]
     ),
   ],
   dependencies: [
@@ -36,23 +36,23 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "grpc-Wrapper",
+      name: "grpcWrapper",
       dependencies: ["grpc"],
       path: "grpc-Wrapper",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")]
     ),
     .target(
-      name: "openssl-grpc-Wrapper",
+      name: "opensslWrapper",
       dependencies: ["openssl_grpc"],
       path: "openssl-grpc-Wrapper",
       resources: [.process("Resources/PrivacyInfo.xcprivacy")]
     ),
     .target(
-      name: "grpcpp-Wrapper",
+      name: "grpcppWrapper",
       dependencies: [
         "grpcpp",
-        "grpc-Wrapper",
-        "openssl-grpc-Wrapper",
+        "grpcWrapper",
+        "opensslWrapper",
         .product(name: "abseil", package: "abseil-cpp-binary"),
       ],
       path: "grpcpp-Wrapper",

--- a/Package.swift
+++ b/Package.swift
@@ -29,11 +29,10 @@ let package = Package(
     ),
   ],
   dependencies: [
-//    .package(
-//        url: "https://github.com/google/abseil-cpp-binary.git",
-//        "1.2022062300.0" ..< "1.2022062400.0"
-//    )
-    .package(path: "/Users/nickcooke/Developer/abseil-cpp-binary")
+    .package(
+        url: "https://github.com/google/abseil-cpp-binary.git",
+        "1.2022062300.1" ..< "1.2022062400.0"
+    )
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -21,51 +21,58 @@ let package = Package(
   products: [
     .library(
       name: "gRPC-Core",
-      targets: ["gRPC-Core"]
+      targets: ["grpc-Wrapper"]
     ),
     .library(
       name: "gRPC-C++",
-      targets: ["gRPC-CXX-Target"]
+      targets: ["grpcpp-Wrapper"]
     ),
   ],
   dependencies: [
-    .package(
-        url: "https://github.com/google/abseil-cpp-binary.git",
-        "1.2022062300.0" ..< "1.2022062400.0"
-    )
+//    .package(
+//        url: "https://github.com/google/abseil-cpp-binary.git",
+//        "1.2022062300.0" ..< "1.2022062400.0"
+//    )
+    .package(path: "/Users/nickcooke/Developer/abseil-cpp-binary")
   ],
   targets: [
     .target(
-      name: "gRPC-CXX-Target",
-      dependencies: [
-        .target(name: "gRPC-CXX-Wrapper")
-      ],
-      path: "SwiftPM-PlatformExclude/gRPC-CXX-Target"
+      name: "grpc-Wrapper",
+      dependencies: ["grpc"],
+      path: "grpc-Wrapper",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")]
     ),
     .target(
-      name: "gRPC-CXX-Wrapper",
+      name: "openssl-grpc-Wrapper",
+      dependencies: ["openssl_grpc"],
+      path: "openssl-grpc-Wrapper",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")]
+    ),
+    .target(
+      name: "grpcpp-Wrapper",
       dependencies: [
-        .target(name: "gRPC-Core"),
-        .target(name: "gRPC-C++"),
-        .target(name: "BoringSSL-GRPC"),
+        "grpcpp",
+        "grpc-Wrapper",
+        "openssl-grpc-Wrapper",
         .product(name: "abseil", package: "abseil-cpp-binary"),
       ],
-      path: "gRPC-CXX-Wrapper"
+      path: "grpcpp-Wrapper",
+      resources: [.process("Resources/PrivacyInfo.xcprivacy")]
     ),
     .binaryTarget(
-      name: "gRPC-Core",
-      url: "https://dl.google.com/firebase/ios/bin/grpc/1.49.1/gRPC-Core.zip",
-      checksum: "ac70d546ec00500ed62e353623f33f469738826c33c1711127c1ced7ba0a003e"
+      name: "grpc",
+      url: "https://dl.google.com/firebase/ios/bin/grpc/1.49.2/grpc.zip",
+      checksum: "99e4a17fd34677622ef2cd99bc742eb079b80219d476544619f6f1583845855e"
     ),
     .binaryTarget(
-      name: "gRPC-C++",
-      url: "https://dl.google.com/firebase/ios/bin/grpc/1.49.1/gRPC-C++.zip",
-      checksum: "7c7e3568804b96cef83184f897a1d11fea753818a6644c9704b3b14be44507e2"
+      name: "grpcpp",
+      url: "https://dl.google.com/firebase/ios/bin/grpc/1.49.2/grpcpp.zip",
+      checksum: "075ed90f7a09589c1d269b7638dd34e50691b13b203305acb82c6248c1c752e1"
     ),
     .binaryTarget(
-        name: "BoringSSL-GRPC",
-        url: "https://dl.google.com/firebase/ios/bin/grpc/1.44.0/BoringSSL-GRPC.zip",
-        checksum: "7ba45f311a17a8b613f96316595f395c76eb7439117f958eba3735caa55e0fd7"
+        name: "openssl_grpc",
+        url: "https://dl.google.com/firebase/ios/bin/grpc/1.49.2/openssl_grpc.zip",
+        checksum: "3cb1cf53fb11a82d5f7e9f90a49a0c976535e5c3a89884b86516939f5b3e0871"
     )
   ]
 )

--- a/grpc-Wrapper/Resources/PrivacyInfo.xcprivacy
+++ b/grpc-Wrapper/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/grpc-Wrapper/empty.m
+++ b/grpc-Wrapper/empty.m
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/grpc-Wrapper/include/empty.h
+++ b/grpc-Wrapper/include/empty.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/grpcpp-Wrapper/Resources/PrivacyInfo.xcprivacy
+++ b/grpcpp-Wrapper/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/grpcpp-Wrapper/empty.m
+++ b/grpcpp-Wrapper/empty.m
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/grpcpp-Wrapper/include/empty.h
+++ b/grpcpp-Wrapper/include/empty.h
@@ -1,0 +1,15 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is intentionally empty.

--- a/openssl-grpc-Wrapper/Resources/PrivacyInfo.xcprivacy
+++ b/openssl-grpc-Wrapper/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/openssl-grpc-Wrapper/empty.m
+++ b/openssl-grpc-Wrapper/empty.m
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/openssl-grpc-Wrapper/include/empty.h
+++ b/openssl-grpc-Wrapper/include/empty.h
@@ -1,0 +1,15 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is intentionally empty.


### PR DESCRIPTION
Test Plan
- [x] Tested and validated with locally hosted binaries
- [x] Tested and validated with remotely hosted binaries

See "🎉" in below file tree to emphasize the SPM wrapper resource bundles.
```
/Users/nickcooke/Library/Developer/Xcode/Archives/2024-02-29/MyCoolApp 2-29-24, 5.29 PM.xcarchive
├── Info.plist
├── Products
│   └── Applications
│       └── MyCoolApp.app
│           ├── AppIcon60x60@2x.png
│           ├── AppIcon76x76@2x~ipad.png
│           ├── Assets.car
│           ├── Firebase_FirebaseCore.bundle
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── Firebase_FirebaseCoreExtension.bundle
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── Firebase_FirebaseCoreInternal.bundle
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── Firebase_FirebaseFirestore.bundle
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── Frameworks
│           │   ├── FirebaseFirestoreInternal.framework
│           │   │   ├── FirebaseFirestoreInternal
│           │   │   ├── FirebaseFirestoreInternal_Privacy.bundle
│           │   │   │   ├── Info.plist
│           │   │   │   └── PrivacyInfo.xcprivacy
│           │   │   ├── Info.plist
│           │   │   └── _CodeSignature
│           │   │       └── CodeResources
│           │   ├── absl.framework 🎯 Notice that Xcode 15.3 embeds
│           │   │   ├── Info.plist
│           │   │   ├── _CodeSignature
│           │   │   │   └── CodeResources
│           │   │   └── absl
│           │   ├── grpc.framework  🎯 Notice that Xcode 15.3 embeds
│           │   │   ├── Info.plist
│           │   │   ├── _CodeSignature
│           │   │   │   └── CodeResources
│           │   │   └── grpc
│           │   ├── grpcpp.framework  🎯 Notice that Xcode 15.3 embeds
│           │   │   ├── Info.plist
│           │   │   ├── _CodeSignature
│           │   │   │   └── CodeResources
│           │   │   └── grpcpp
│           │   └── openssl_grpc.framework  🎯 Notice that Xcode 15.3 embeds
│           │       ├── Info.plist
│           │       ├── _CodeSignature
│           │       │   └── CodeResources
│           │       └── openssl_grpc
│           ├── GoogleUtilities_GoogleUtilities-Privacy.bundle
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── Info.plist
│           ├── MyCoolApp
│           ├── PkgInfo
│           ├── PrivacyInfo.xcprivacy
│           ├── Promises_FBLPromises.bundle
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── _CodeSignature
│           │   └── CodeResources
│           ├── abseil_absl-Wrapper.bundle 🎉
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── embedded.mobileprovision
│           ├── gRPC_grpc-Wrapper.bundle 🎉
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── gRPC_grpcpp-Wrapper.bundle 🎉
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── gRPC_openssl-grpc-Wrapper.bundle 🎉
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           ├── leveldb_leveldb.bundle
│           │   ├── Info.plist
│           │   └── PrivacyInfo.xcprivacy
│           └── nanopb_nanopb.bundle
│               ├── Info.plist
│               └── PrivacyInfo.xcprivacy
├── Signatures
│   ├── FirebaseFirestoreInternal.xcframework-ios.signature
│   ├── absl.xcframework-ios.signature
│   ├── grpc.xcframework-ios.signature
│   ├── grpcpp.xcframework-ios.signature
│   └── openssl_grpc.xcframework-ios.signature
└── dSYMs
    └── MyCoolApp.app.dSYM
        └── Contents
            ├── Info.plist
            └── Resources
                ├── DWARF
                │   └── MyCoolApp
                └── Relocations
                    └── aarch64
                        └── MyCoolApp.yml

37 directories, 59 files
```

Release Plan
- GRPC/BoringSSL: tag `1.49.2` (patch update – our tagging strategy is not ideal for this one)
  - No changes in Firebase's `Package.swift` are needed because it depends on `"1.49.1" ..< "1.50.0"` https://github.com/firebase/firebase-ios-sdk/blob/fe09d61a539e11fdbe24f269bba10144b6145fe2/Package.swift#L1358
- Abseil: tag `1.2022062300.1` (patch update)
  - No changes in Firebase's `Package.swift` are needed because it depends on `"1.2022062300.0" ..< "1.2022062400.0"` https://github.com/firebase/firebase-ios-sdk/blob/fe09d61a539e11fdbe24f269bba10144b6145fe2/Package.swift#L1343